### PR TITLE
오타 수정 및 ReSwift 란 별도 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,10 @@ iOS의 Swift 동영상 강의 링크 정보를 모아보았습니다.
 
 - [Feb 23 2017, RxSwift 예제로 감잡기 : RxSwift 시작을 위한 간단한 예제들 - iOS Tech Talk](https://academy.realm.io/kr/posts/how-to-use-rxswift-with-simple-examples-ios-techtalk/)
 
-- [RxSwift로 리액티브 프로그래밍 구현하기](https://www.youtube.com/watch?v=H0WPEAnC5YQ&feature=youtu.be)
-
 - [Jul 4 2017, RxSwift로 반응형 프로그래밍하기](https://academy.realm.io/kr/posts/reactive-programming-with-rxswift/)
+
+## ReSwift
+- [ReSwift로 리액티브 프로그래밍 구현하기](https://www.youtube.com/watch?v=H0WPEAnC5YQ&feature=youtu.be)
 
 * * *
 


### PR DESCRIPTION
RxSwift의 목록 중에 `RxSwift로 리액티브 프로그래밍 구현하기`라는 영상이 사실 RxSwift가 아닌 ReSwift에 대한 영상인 것을 발견하고 PR 드립니다. 제목을 수정하고 ReSwift 란을 별도로 구성하여 정리해두었습니다.

영상에 나오는 swift korea meetup 때 제가 참석해서 기억이 나네요. 맨 왼쪽 머리가 저입니다 ㅎㅁㅎ;
그리고 [개발자 회고 모음](https://github.com/oaksong/developers-retrospective) 공유해주셔서 감사합니다!